### PR TITLE
Switch input system to leafwing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,10 @@ name = "accesskit"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_consumer"
@@ -338,6 +342,7 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
+ "serde",
 ]
 
 [[package]]
@@ -732,6 +737,7 @@ dependencies = [
  "bevy_utils",
  "derive_more",
  "log",
+ "serde",
  "smol_str",
  "thiserror 2.0.16",
 ]
@@ -1259,6 +1265,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "nonmax",
+ "serde",
  "smallvec",
  "taffy",
  "thiserror 2.0.16",
@@ -1323,6 +1330,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-channel",
  "raw-window-handle",
+ "serde",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -1891,6 +1899,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +1948,17 @@ name = "encase_derive_impl"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2131,6 +2168,7 @@ name = "game"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "leafwing-input-manager",
  "regex",
  "tokio",
 ]
@@ -2456,13 +2494,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2570,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2609,6 +2648,34 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leafwing-input-manager"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ac3ba8262c0e42b22bb917c18ef9dbe773e2b6b279c61a4a520c5d960b5e1a"
+dependencies = [
+ "bevy",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
+ "itertools 0.14.0",
+ "leafwing_input_manager_macros",
+ "serde",
+ "serde_flexitos",
+]
+
+[[package]]
+name = "leafwing_input_manager_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2226cb83129176a6c634f2ce0828c2c29896ea0898fc198636f98696b8056890"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "lewton"
@@ -3758,22 +3825,42 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_flexitos"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323d093d7597660758b742dd7a1525539613f6182b306a4e1dd6e01a89bada9"
+dependencies = [
+ "erased-serde",
+ "serde",
 ]
 
 [[package]]
@@ -3848,6 +3935,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smol_str"
@@ -4354,21 +4444,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -4380,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4393,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4403,9 +4494,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4416,18 +4507,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ default-run = "game"
 
 bevy = { version = "0.16.1", features = ["dynamic_linking"] }
 leafwing-input-manager = "0.17.0"
-# lightyear = { version = "0.24.2", features = ["leafwing"] }
 regex = "1.11.2"
-# serde = "1.0.226"
 tokio = { version = "1.47.1", features = ["full"] }
 
 # Enable a small amount of optimization in the dev profile.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ default-run = "game"
 [dependencies]
 
 bevy = { version = "0.16.1", features = ["dynamic_linking"] }
+leafwing-input-manager = "0.17.0"
+# lightyear = { version = "0.24.2", features = ["leafwing"] }
 regex = "1.11.2"
+# serde = "1.0.226"
 tokio = { version = "1.47.1", features = ["full"] }
 
 # Enable a small amount of optimization in the dev profile.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,2 +1,5 @@
+mod input;
 mod state;
+
+pub use input::*;
 pub use state::*;

--- a/src/common/input.rs
+++ b/src/common/input.rs
@@ -1,0 +1,23 @@
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+
+pub const MOUSE_SENSITIVITY: f32 = 0.002;
+
+pub fn default_input_map() -> InputMap<Action> {
+    InputMap::default()
+        .with_dual_axis(Action::MoveHorizontal, VirtualDPad::wasd())
+        .with_dual_axis(Action::Look, MouseMove::default())
+        .with_axis(
+            Action::MoveVertical,
+            VirtualAxis::new(KeyCode::ShiftLeft, KeyCode::Space),
+        )
+}
+
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[actionlike(DualAxis)]
+pub enum Action {
+    MoveHorizontal,
+    Look,
+    #[actionlike(Axis)]
+    MoveVertical,
+}

--- a/src/common/input.rs
+++ b/src/common/input.rs
@@ -3,21 +3,41 @@ use leafwing_input_manager::prelude::*;
 
 pub const MOUSE_SENSITIVITY: f32 = 0.002;
 
-pub fn default_input_map() -> InputMap<Action> {
+pub struct InputPlugin;
+impl Plugin for InputPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(InputManagerPlugin::<GameAction>::default())
+            .add_plugins(InputManagerPlugin::<MenuAction>::default())
+            .init_resource::<ActionState<MenuAction>>()
+            .insert_resource(MenuAction::default_menu_action_map());
+    }
+}
+
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[actionlike(DualAxis)]
+pub enum GameAction {
+    MoveHorizontal,
+    Look,
+    #[actionlike(Axis)]
+    MoveVertical,
+}
+
+pub fn default_game_action_map() -> InputMap<GameAction> {
     InputMap::default()
-        .with_dual_axis(Action::MoveHorizontal, VirtualDPad::wasd())
-        .with_dual_axis(Action::Look, MouseMove::default())
+        .with_dual_axis(GameAction::MoveHorizontal, VirtualDPad::wasd())
+        .with_dual_axis(GameAction::Look, MouseMove::default())
         .with_axis(
-            Action::MoveVertical,
+            GameAction::MoveVertical,
             VirtualAxis::new(KeyCode::ShiftLeft, KeyCode::Space),
         )
 }
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
-#[actionlike(DualAxis)]
-pub enum Action {
-    MoveHorizontal,
-    Look,
-    #[actionlike(Axis)]
-    MoveVertical,
+pub enum MenuAction {
+    ToggleMenu,
+}
+impl MenuAction {
+    fn default_menu_action_map() -> InputMap<MenuAction> {
+        InputMap::default().with(MenuAction::ToggleMenu, KeyCode::Escape)
+    }
 }

--- a/src/common/state.rs
+++ b/src/common/state.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::States;
 
 #[derive(States, Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub enum AppState {
+pub enum GameState {
     #[default]
     Menu,
     Playing,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use bevy::prelude::*;
-use game::common::AppState;
+use game::common::{Action, AppState};
 use game::plugins::*;
 use game::ui::UiPlugin;
+use leafwing_input_manager::plugin::InputManagerPlugin;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .add_plugins(InputManagerPlugin::<Action>::default())
         .init_state::<AppState>()
         .add_plugins(WorldPlugin)
         .add_plugins(UiPlugin)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,13 @@
 use bevy::prelude::*;
-use game::common::{Action, AppState};
+use game::common::{GameState, InputPlugin};
 use game::plugins::*;
 use game::ui::UiPlugin;
-use leafwing_input_manager::plugin::InputManagerPlugin;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(InputManagerPlugin::<Action>::default())
-        .init_state::<AppState>()
+        .add_plugins(InputPlugin)
+        .init_state::<GameState>()
         .add_plugins(WorldPlugin)
         .add_plugins(UiPlugin)
         .add_plugins(PlayerPlugin)

--- a/src/plugins/camera.rs
+++ b/src/plugins/camera.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::window::CursorGrabMode;
 
-use crate::common::AppState;
+use crate::common::GameState;
 use crate::plugins::movement::update_position;
 use crate::plugins::player::Player;
 
@@ -12,13 +12,13 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup)
-            .add_systems(OnEnter(AppState::Playing), lock_cursor)
-            .add_systems(OnExit(AppState::Playing), unlock_cursor)
+            .add_systems(OnEnter(GameState::Playing), lock_cursor)
+            .add_systems(OnExit(GameState::Playing), unlock_cursor)
             .add_systems(
                 Update,
                 orbit
                     .after(update_position)
-                    .run_if(in_state(AppState::Playing)),
+                    .run_if(in_state(GameState::Playing)),
             );
     }
 }

--- a/src/plugins/movement.rs
+++ b/src/plugins/movement.rs
@@ -15,10 +15,8 @@ impl Plugin for MovementPlugin {
     }
 }
 
-pub fn update_position(mut query: Query<(&Velocity, &mut Transform)>) {
+pub fn update_position(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
     for (velocity, mut transform) in query.iter_mut() {
-        transform.translation.x += velocity.value.x;
-        transform.translation.y += velocity.value.y;
-        transform.translation.z += velocity.value.z;
+        transform.translation += time.delta_secs() * velocity.value;
     }
 }

--- a/src/plugins/movement.rs
+++ b/src/plugins/movement.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use crate::common::AppState;
+use crate::common::GameState;
 
 pub struct MovementPlugin;
 
@@ -11,7 +11,7 @@ pub struct Velocity {
 
 impl Plugin for MovementPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, update_position.run_if(in_state(AppState::Playing)));
+        app.add_systems(Update, update_position.run_if(in_state(GameState::Playing)));
     }
 }
 

--- a/src/plugins/player.rs
+++ b/src/plugins/player.rs
@@ -1,95 +1,85 @@
-use bevy::{input::mouse::MouseMotion, prelude::*};
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
 
-use crate::common::AppState;
+use crate::common::*;
 use crate::plugins::movement::Velocity;
 use crate::plugins::world::VoxelResource;
 use crate::plugins::world::init_resources;
 
-const INIT_TRANSLATION: Vec3 = Vec3::new(0.0, 0.0, 0.0);
-const INIT_VELOCITY: Vec3 = Vec3::new(0.0, 0.0, 0.0);
+const INIT_VELOCITY: Vec3 = Vec3::ZERO;
 const PLAYER_SPEED: f32 = 0.5;
-pub const PLAYER_SCALE: f32 = 0.5;
+const PLAYER_SCALE: f32 = 0.5;
 
-#[derive(Component, Debug)]
+type Movement = (
+    &'static mut Transform,
+    &'static mut Velocity,
+    &'static mut Angles2D,
+);
+
+#[derive(Component)]
 pub struct Player;
+
+#[derive(Component)]
+struct Angles2D {
+    yaw: f32,
+    pitch: f32,
+}
 
 pub struct PlayerPlugin;
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, spawn_character.after(init_resources))
+        app.add_systems(Startup, spawn_player.after(init_resources))
             .add_systems(
                 Update,
-                (mouse_look, player_movement).run_if(in_state(AppState::Playing)),
+                (player_look, player_move).run_if(in_state(AppState::Playing)),
             );
     }
 }
 
-fn spawn_character(mut commands: Commands, voxel: Res<VoxelResource>) {
+fn spawn_player(mut commands: Commands, voxel: Res<VoxelResource>) {
     commands.spawn((
         Mesh3d(voxel.mesh.clone()),
         MeshMaterial3d(voxel.materials[0].clone()),
         Transform {
-            translation: INIT_TRANSLATION,
-            rotation: Quat::IDENTITY,
             scale: Vec3::new(PLAYER_SCALE, PLAYER_SCALE, PLAYER_SCALE),
+            ..default()
+        },
+        Angles2D {
+            yaw: 0.0,
+            pitch: 0.0,
         },
         Player,
         Velocity {
             value: INIT_VELOCITY,
         },
+        default_input_map(),
     ));
 }
 
-fn player_movement(
-    mut next_state: ResMut<NextState<AppState>>,
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut query: Query<(&Transform, &mut Velocity), With<Player>>,
-) {
-    let (transform, mut velocity) = query.single_mut().unwrap();
+fn player_look(single: Single<(Movement, &ActionState<Action>), With<Player>>) {
+    let ((mut transform, _, mut angles), action_state) = single.into_inner();
 
-    let forward = transform.forward().as_vec3();
-    let forward_flat = Vec3::new(forward.x, 0.0, forward.z).normalize_or_zero();
-    let right = transform.right().as_vec3();
-    let right_flat = Vec3::new(right.x, 0.0, right.z).normalize_or_zero();
+    let mouse_delta = action_state.axis_pair(&Action::Look);
+    angles.yaw -= mouse_delta.x * MOUSE_SENSITIVITY;
+    angles.pitch = (angles.pitch - mouse_delta.y * MOUSE_SENSITIVITY)
+        .clamp(-std::f32::consts::FRAC_PI_2, std::f32::consts::FRAC_PI_2);
 
-    let mut direction = Vec3::ZERO;
-    if keyboard_input.pressed(KeyCode::KeyW) {
-        direction += forward_flat;
-    }
-    if keyboard_input.pressed(KeyCode::KeyS) {
-        direction -= forward_flat;
-    }
-    if keyboard_input.pressed(KeyCode::KeyA) {
-        direction -= right_flat;
-    }
-    if keyboard_input.pressed(KeyCode::KeyD) {
-        direction += right_flat;
-    }
-    if keyboard_input.pressed(KeyCode::Space) {
-        direction += Vec3::Y;
-    }
-    if keyboard_input.pressed(KeyCode::ShiftLeft) {
-        direction -= Vec3::Y;
-    }
-    if keyboard_input.pressed(KeyCode::Escape) {
-        next_state.set(AppState::Menu);
-    }
-    velocity.value = direction.normalize_or_zero() * PLAYER_SPEED;
+    transform.rotation = Quat::from_rotation_y(angles.yaw) * Quat::from_rotation_x(angles.pitch);
 }
 
-fn mouse_look(
-    mut mouse_motion: EventReader<MouseMotion>,
-    mut query: Query<&mut Transform, With<Player>>,
-) {
-    let mut transform = query.single_mut().unwrap();
+fn player_move(single: Single<(Movement, &ActionState<Action>), With<Player>>) {
+    let ((_, mut velocity, angles), action_state) = single.into_inner();
+    let mut direction = Vec3::ZERO;
+    let yaw_rot = Quat::from_rotation_y(angles.yaw);
 
-    let delta = mouse_motion
-        .read()
-        .fold(Vec2::ZERO, |curr, ev| curr + ev.delta);
+    // Horizontal direction handling
+    let hori = action_state.clamped_axis_pair(&Action::MoveHorizontal);
+    direction += hori.x * (yaw_rot * Vec3::X).normalize();
+    direction += hori.y * -(yaw_rot * Vec3::Z).normalize();
 
-    if delta != Vec2::ZERO {
-        let sensitivity = 0.002;
-        transform.rotation = Quat::from_rotation_y(-delta.x * sensitivity) * transform.rotation;
-        transform.rotation *= Quat::from_rotation_x(-delta.y * sensitivity);
-    }
+    // Vertical direction handling
+    let vert = action_state.clamped_value(&Action::MoveVertical);
+    direction += vert * Vec3::Y;
+
+    velocity.value = direction.normalize_or_zero() * PLAYER_SPEED;
 }

--- a/src/plugins/player.rs
+++ b/src/plugins/player.rs
@@ -7,7 +7,7 @@ use crate::plugins::world::VoxelResource;
 use crate::plugins::world::init_resources;
 
 const INIT_VELOCITY: Vec3 = Vec3::ZERO;
-const PLAYER_SPEED: f32 = 0.5;
+const PLAYER_SPEED: f32 = 15.0;
 const PLAYER_SCALE: f32 = 0.5;
 
 type Movement = (

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{AppState, MenuState},
+    common::{GameState, MenuState},
     ui::components::button::*,
     ui::shared::ButtonInteraction,
 };
@@ -74,7 +74,7 @@ impl Plugin for MainMenu {
 }
 fn main_menu(
     mut exit: EventWriter<AppExit>,
-    mut next_state: ResMut<NextState<AppState>>,
+    mut next_state: ResMut<NextState<GameState>>,
     mut next_menu_state: ResMut<NextState<MenuState>>,
     mut query: Query<(&Interaction, &MenuButtonAction), ButtonInteraction>,
 ) {
@@ -84,7 +84,7 @@ fn main_menu(
         }
 
         match action {
-            MenuButtonAction::Play => next_state.set(AppState::Playing),
+            MenuButtonAction::Play => next_state.set(GameState::Playing),
             MenuButtonAction::Multiplayer => next_menu_state.set(MenuState::Multiplayer),
             MenuButtonAction::Quit => {
                 exit.write(AppExit::Success);

--- a/src/ui/shared.rs
+++ b/src/ui/shared.rs
@@ -1,20 +1,36 @@
-use crate::common::{AppState, MenuState};
+use crate::common::{GameState, MenuAction, MenuState};
 use crate::ui::components::button::*;
 use crate::ui::menu::*;
 use bevy::prelude::*;
+use leafwing_input_manager::prelude::ActionState;
 
 pub struct UiPlugin;
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
         app.init_state::<MenuState>()
             .init_resource::<InputFocus>()
-            .add_systems(OnEnter(AppState::Menu), enter_menu)
-            .add_systems(OnExit(AppState::Menu), leave_menu)
-            .add_systems(Update, button_system.run_if(in_state(AppState::Menu)))
+            .add_systems(OnEnter(GameState::Menu), enter_menu)
+            .add_systems(OnExit(GameState::Menu), leave_menu)
+            .add_systems(Update, toggle_menu)
+            .add_systems(Update, button_system.run_if(in_state(GameState::Menu)))
             .add_plugins(MainMenu)
             .add_plugins(MultiplayerMenu);
     }
 }
+
+fn toggle_menu(
+    action_state: Res<ActionState<MenuAction>>,
+    game_state: Res<State<GameState>>,
+    mut next_game_state: ResMut<NextState<GameState>>,
+) {
+    if action_state.just_pressed(&MenuAction::ToggleMenu) {
+        match game_state.get() {
+            GameState::Playing => next_game_state.set(GameState::Menu),
+            GameState::Menu => next_game_state.set(GameState::Playing),
+        }
+    }
+}
+
 fn enter_menu(mut next_menu_state: ResMut<NextState<MenuState>>) {
     next_menu_state.set(MenuState::Main)
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? If making a visual change, include screenshots where necessary -->
Switch our input system to `leafwing-input-manager`

## Motivation
<!-- Why are you making this change? Link issue, if applicable -->

1. Makes networking and sending inputs across the wire easier
2. Makes it easier if we want controller support or allowing users to remap keybinds in the future

## Changes
- [x] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Documentation

## Testing
<!-- How did you test this? -->

All inputs existing inputs work

## Checklist
- [x] Code formatted (`cargo fmt --all -- --check`)
- [x] Clippy passes (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Tests pass (`cargo test --all`)
